### PR TITLE
8351283 update null restricted tests

### DIFF
--- a/src/java.base/share/classes/jdk/internal/value/ValueClass.java
+++ b/src/java.base/share/classes/jdk/internal/value/ValueClass.java
@@ -27,25 +27,29 @@ package jdk.internal.value;
 
 import jdk.internal.access.JavaLangReflectAccess;
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.misc.Unsafe;
-import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 
 /**
- * Utilities to access
+ * Utilities to access package private methods of java.lang.Class and related reflection classes.
  */
 public class ValueClass {
-    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
     private static final JavaLangReflectAccess JLRA = SharedSecrets.getJavaLangReflectAccess();
 
     /**
      * {@return {@code CheckedType} representing the type of the given field}
      */
     public static CheckedType checkedType(Field f) {
-        return JLRA.isNullRestrictedField(f) ? NullRestrictedCheckedType.of(f.getType())
+        return isNullRestrictedField(f) ? NullRestrictedCheckedType.of(f.getType())
                                              : NormalCheckedType.of(f.getType());
+    }
+
+    /**
+     * {@return {@code true} if the field is NullRestricted}
+     */
+    public static boolean isNullRestrictedField(Field f) {
+        return JLRA.isNullRestrictedField(f);
     }
 
     /**
@@ -66,15 +70,15 @@ public class ValueClass {
      * this method should only be used by internal JDK code for experimental
      * purposes and should not affect user-observable outcomes.
      *
-     * @throws IllegalArgumentException if {@code componentType} is not a
-     *         value class type or is not annotated with
-     *         {@link jdk.internal.vm.annotation.ImplicitlyConstructible}
+     * @param componentType the CheckedType componentType
+     * @param length length of the array
+     * @param initVal the object to initialize NullRestricted arrays with
+     * @throws IllegalArgumentException if {@code componentType} is not a value class type
      */
-    @SuppressWarnings("unchecked")
-    public static Object[] newArrayInstance(CheckedType componentType, int length) {
+    public static Object[] newArrayInstance(CheckedType componentType, int length, Object initVal) {
         if (componentType instanceof NullRestrictedCheckedType) {
-            throw new RuntimeException("Not supported yet");
-            // return newNullRestrictedArray(componentType.boundingClass(), length);
+            // Only support atomic NullRestricted arrays
+            return newNullRestrictedAtomicArray(componentType.boundingClass(), length, initVal);
         } else {
             return (Object[]) Array.newInstance(componentType.boundingClass(), length);
         }

--- a/src/java.base/share/classes/jdk/internal/value/ValueClass.java
+++ b/src/java.base/share/classes/jdk/internal/value/ValueClass.java
@@ -80,24 +80,6 @@ public class ValueClass {
         }
     }
 
-    /**
-     * Allocate an array of a value class type with components that behave in
-     * the same way as a {@link jdk.internal.vm.annotation.NullRestricted}
-     * field.
-     * <p>
-     * Because these behaviors are not specified by Java SE, arrays created with
-     * this method should only be used by internal JDK code for experimental
-     * purposes and should not affect user-observable outcomes.
-     *
-     * @throws IllegalArgumentException if {@code componentType} is not a
-     *         value class type or is not annotated with
-     *         {@link jdk.internal.vm.annotation.ImplicitlyConstructible}
-     */
-    @IntrinsicCandidate
-    public static native Object[] newNullRestrictedArray(Class<?> componentType,
-                                                         int length);
-
-
     public static Object[] newNullRestrictedNonAtomicArray(Class<?> componentType,
                                                            int length, Object initVal) {
         return newNullRestrictedNonAtomicArray0(componentType, length, initVal);

--- a/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.lang.invoke.*;
 import java.util.stream.Stream;
 
 import jdk.internal.vm.annotation.NullRestricted;
+import jdk.internal.vm.annotation.Strict;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -50,9 +51,9 @@ public class ArrayElementVarHandleTest {
     }
 
     static value class Line {
-        @NullRestricted
+        @NullRestricted  @Strict
         Point p1;
-        @NullRestricted
+        @NullRestricted  @Strict
         Point p2;
 
         Line(Point p1, Point p2) {

--- a/test/jdk/valhalla/valuetypes/LambdaMetaFactory/LambdaTest.java
+++ b/test/jdk/valhalla/valuetypes/LambdaMetaFactory/LambdaTest.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 import java.util.function.IntFunction;
 
 import jdk.internal.vm.annotation.NullRestricted;
+import jdk.internal.vm.annotation.Strict;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -48,7 +49,7 @@ public class LambdaTest {
     }
 
     static value class Value {
-        @NullRestricted
+        @NullRestricted  @Strict
         V v;
         Value(V v) {
             this.v = v;

--- a/test/jdk/valhalla/valuetypes/MethodHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/MethodHandleTest.java
@@ -59,9 +59,9 @@ public class MethodHandleTest {
 
     @LooselyConsistentValue
     static value class Line {
-        @NullRestricted
+        @NullRestricted  @Strict
         Point p1;
-        @NullRestricted
+        @NullRestricted  @Strict
         Point p2;
 
         Line(int x1, int y1, int x2, int y2) {
@@ -71,8 +71,7 @@ public class MethodHandleTest {
     }
 
     static class Ref {
-        @Strict
-        @NullRestricted
+        @NullRestricted  @Strict
         Point p;
         Line l;
         List<String> list;
@@ -163,9 +162,9 @@ public class MethodHandleTest {
     static Stream<Arguments> arrays() throws Throwable {
         return Stream.of(
                 Arguments.of(Point[].class, newArray(Point[].class), P, false),
-                Arguments.of(Point[].class, newNullRestrictedArray(Point.class, new Point(0, 0)), P, true),
+                Arguments.of(Point[].class, newNullRestrictedNonAtomicArray(Point.class, new Point(0, 0)), P, true),
                 Arguments.of(Line[].class, newArray(Line[].class), L, false),
-                Arguments.of(Line[].class, newNullRestrictedArray(Line.class, new Line(0, 0, 0, 0)), L, true),
+                Arguments.of(Line[].class, newNullRestrictedNonAtomicArray(Line.class, new Line(0, 0, 0, 0)), L, true),
                 Arguments.of(Ref[].class, newArray(Ref[].class), R, false)
         );
     }
@@ -175,7 +174,7 @@ public class MethodHandleTest {
         MethodHandle ctor = MethodHandles.arrayConstructor(arrayClass);
         return (Object[])ctor.invoke(ARRAY_SIZE);
     }
-    private static Object[] newNullRestrictedArray(Class<?> componentClass, Object initVal) throws Throwable {
+    private static Object[] newNullRestrictedNonAtomicArray(Class<?> componentClass, Object initVal) throws Throwable {
         return ValueClass.newNullRestrictedNonAtomicArray(componentClass, ARRAY_SIZE, initVal);
     }
 

--- a/test/jdk/valhalla/valuetypes/MethodReference.java
+++ b/test/jdk/valhalla/valuetypes/MethodReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/valhalla/valuetypes/Nest.java
+++ b/test/jdk/valhalla/valuetypes/Nest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,14 +44,12 @@ public class Nest {
         assertEquals(n2.new Inner(10), new Outer(2).new Inner(10));
     }
 
-    @ImplicitlyConstructible
     value class Outer {
         final int i;
         Outer(int i) {
             this.i = i;
         }
 
-        @ImplicitlyConstructible
         value class Inner {
             final int ic;
             Inner(int ic) {

--- a/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @ignore until more updates are done
  * @enablePreview
  * @run junit/othervm NullRestrictedArraysTest
  * @run junit/othervm -XX:-UseArrayFlattening NullRestrictedArraysTest
@@ -69,8 +70,7 @@ public class NullRestrictedArraysTest {
     static class T {
         String s;
         Value obj;  // can be null
-        @Strict
-        @NullRestricted
+        @NullRestricted  @Strict
         Value value;
     }
 
@@ -112,7 +112,7 @@ public class NullRestrictedArraysTest {
     public void testArraysCopyOf() {
         int len = 4;
         Object[] array = (Object[]) Array.newInstance(Value.class, len);
-        Object[] nullRestrictedArray = ValueClass.newNullRestrictedArray(Value.class, len);
+        Object[] nullRestrictedArray = ValueClass.newNullRestrictedNonAtomicArray(Value.class, len, new Value());
         for (int i=0; i < len; i++) {
             array[i] = new Value(i);
             nullRestrictedArray[i] = new Value(i);
@@ -168,7 +168,7 @@ public class NullRestrictedArraysTest {
     public void testVarHandle() {
         int len = 4;
         Object[] array = (Object[]) Array.newInstance(Value.class, len);
-        Object[] nullRestrictedArray = ValueClass.newNullRestrictedArray(Value.class, len);
+        Object[] nullRestrictedArray = ValueClass.newNullRestrictedNonAtomicArray(Value.class, len, new Value());
 
         // Test var handles
         testVarHandleArray(array, Value[].class);

--- a/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
@@ -54,8 +54,7 @@ public class NullRestrictedTest {
 
     static value class Value {
         Object o;
-        @Strict
-        @NullRestricted
+        @NullRestricted  @Strict
         EmptyValue empty;
         Value() {
             this.o = null;
@@ -69,11 +68,9 @@ public class NullRestrictedTest {
 
     static class Mutable {
         EmptyValue o;
-        @Strict
-        @NullRestricted
+        @NullRestricted  @Strict
         EmptyValue empty = new EmptyValue();
-        @Strict
-        @NullRestricted
+        @NullRestricted  @Strict
         volatile EmptyValue vempty = new EmptyValue();
     }
 

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -54,9 +54,9 @@ public class ObjectMethods {
     }
 
     static value class Line {
-        @NullRestricted
+        @NullRestricted  @Strict
         Point p1;
-        @NullRestricted
+        @NullRestricted  @Strict
         Point p2;
 
         Line(int x1, int y1, int x2, int y2) {
@@ -66,8 +66,7 @@ public class ObjectMethods {
     }
 
     static class Ref {
-        @Strict
-        @NullRestricted
+        @NullRestricted  @Strict
         Point p;
         Line l;
         Ref(Point p, Line l) {
@@ -77,9 +76,9 @@ public class ObjectMethods {
     }
 
     static value class Value {
-        @NullRestricted
+        @NullRestricted  @Strict
         Point p;
-        @NullRestricted
+        @NullRestricted  @Strict
         Line l;
         Ref r;
         String s;

--- a/test/jdk/valhalla/valuetypes/ObjectNewInstance.java
+++ b/test/jdk/valhalla/valuetypes/ObjectNewInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/valhalla/valuetypes/ProxyTest.java
+++ b/test/jdk/valhalla/valuetypes/ProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,6 @@ public class ProxyTest {
         }
     }
 
-    @ImplicitlyConstructible
     static value class P {
         int p;
         P(int p) {

--- a/test/jdk/valhalla/valuetypes/RecursiveValueClass.java
+++ b/test/jdk/valhalla/valuetypes/RecursiveValueClass.java
@@ -50,7 +50,6 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class RecursiveValueClass {
-    @ImplicitlyConstructible
     static value class Node {
         Node left;
         Node right;
@@ -61,7 +60,6 @@ public class RecursiveValueClass {
         }
     }
 
-    @ImplicitlyConstructible
     static value class P {
         Node node;
         V v;
@@ -71,7 +69,6 @@ public class RecursiveValueClass {
         }
     }
 
-    @ImplicitlyConstructible
     static value class V {
         P p;
         V(P p) {
@@ -79,7 +76,6 @@ public class RecursiveValueClass {
         }
     }
 
-    @ImplicitlyConstructible
     static value class A {
         B b;
         E e;
@@ -89,7 +85,6 @@ public class RecursiveValueClass {
         }
     }
 
-    @ImplicitlyConstructible
     static value class B {
         C c;
         D d;
@@ -99,7 +94,6 @@ public class RecursiveValueClass {
         }
     }
 
-    @ImplicitlyConstructible
     static value class C {
         A a;
         C(A a) {
@@ -107,7 +101,6 @@ public class RecursiveValueClass {
         }
     }
 
-    @ImplicitlyConstructible
     static value class D {
         int x;
         D(int x) {
@@ -115,7 +108,6 @@ public class RecursiveValueClass {
         }
     }
 
-    @ImplicitlyConstructible
     static value class E {
         F f;
         E(F f) {
@@ -123,7 +115,6 @@ public class RecursiveValueClass {
         }
     }
 
-    @ImplicitlyConstructible
     static value class F {
         E e;
         F(E e) {
@@ -257,7 +248,6 @@ public class RecursiveValueClass {
         assertEquals(System.identityHashCode(o), hc, o.toString());
     }
 
-    @ImplicitlyConstructible
     static value class N {
         N l;
         N r;

--- a/test/jdk/valhalla/valuetypes/Reflection.java
+++ b/test/jdk/valhalla/valuetypes/Reflection.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 import jdk.internal.value.ValueClass;
 import jdk.internal.vm.annotation.LooselyConsistentValue;
 import jdk.internal.vm.annotation.NullRestricted;
+import jdk.internal.vm.annotation.Strict;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -57,7 +58,7 @@ public class Reflection {
 
     @LooselyConsistentValue
     static value class Value {
-        @NullRestricted
+        @NullRestricted  @Strict
         V v1;
         V v2;
         Value(V v1, V v2) {

--- a/test/jdk/valhalla/valuetypes/StreamTest.java
+++ b/test/jdk/valhalla/valuetypes/StreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
  */
 
 import jdk.internal.vm.annotation.NullRestricted;
+import jdk.internal.vm.annotation.Strict;
 
 import java.util.Arrays;
 import java.util.List;
@@ -60,7 +61,7 @@ public class StreamTest {
 
     static value class Value {
         int i;
-        @NullRestricted
+        @NullRestricted  @Strict
         Point p;
         Point nullable;
         List<X> list;

--- a/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
+++ b/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 
 import jdk.internal.value.ValueClass;
 import jdk.internal.vm.annotation.NullRestricted;
+import jdk.internal.vm.annotation.Strict;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -54,9 +55,9 @@ public class SubstitutabilityTest {
     }
 
     static value class Line {
-        @NullRestricted
+        @NullRestricted  @Strict
         Point p1;
-        @NullRestricted
+        @NullRestricted  @Strict
         Point p2;
 
         Line(Point p1, Point p2) {
@@ -71,7 +72,7 @@ public class SubstitutabilityTest {
     // contains null-reference and null-restricted fields
     static value class MyValue {
         MyValue2 v1;
-        @NullRestricted
+        @NullRestricted  @Strict
         MyValue2 v2;
         public MyValue(MyValue2 v1, MyValue2 v2) {
             this.v1 = v1;

--- a/test/jdk/valhalla/valuetypes/UseValueClassTest.java
+++ b/test/jdk/valhalla/valuetypes/UseValueClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/valhalla/valuetypes/ValueConstantDesc.java
+++ b/test/jdk/valhalla/valuetypes/ValueConstantDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/valhalla/valuetypes/WeakReferenceTest.java
+++ b/test/jdk/valhalla/valuetypes/WeakReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ import static org.testng.Assert.*;
  */
 @Test
 public class WeakReferenceTest {
-    @ImplicitlyConstructible
     static value class Value {
     }
 


### PR DESCRIPTION
Fix tests as needed by strict NullRestricted PR/1389.
Remove \@ImplicitlyConstructable
Adding \@Strict where needed by \NullRestricted
Updated internal ValueClass support for NullRestricted arrays.

There changes are dependent on PR/1389 and may be integrated into PR/1389 or applied after it is.